### PR TITLE
Fix/spark 1.6

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -36,7 +36,7 @@
   <properties>
     <sbt.project.name>hbase</sbt.project.name>
     <project.version>1.4.1</project.version>
-    <spark.version>1.4.1</spark.version>
+    <spark.version>1.6.0</spark.version>
     <hadoop.version>2.6.0</hadoop.version>
     <hbase.version>1.1.1</hbase.version>
 

--- a/src/main/scala/org/apache/spark/sql/execution/datasources/hbase/HBaseTableCatalog.scala
+++ b/src/main/scala/org/apache/spark/sql/execution/datasources/hbase/HBaseTableCatalog.scala
@@ -21,7 +21,7 @@ import org.apache.avro.Schema
 import org.apache.hadoop.hbase.util.Bytes
 import org.apache.spark.Logging
 import org.apache.spark.sql.SQLContext
-import org.apache.spark.sql.execution.SparkSqlSerializer
+import org.apache.spark.sql.catalyst.util.DataTypeParser
 import org.apache.spark.sql.types._
 import org.json4s.jackson.JsonMethods._
 

--- a/src/main/scala/org/apache/spark/sql/execution/datasources/hbase/HBaseTableScan.scala
+++ b/src/main/scala/org/apache/spark/sql/execution/datasources/hbase/HBaseTableScan.scala
@@ -26,7 +26,6 @@ import org.apache.hadoop.hbase.util.Bytes
 import org.apache.spark._
 import org.apache.spark.rdd.RDD
 import org.apache.spark.sql.Row
-import org.apache.spark.sql.catalyst.expressions.GenericRowWithSchema
 import org.apache.spark.sql.execution.datasources.hbase
 import org.apache.spark.sql.execution.datasources.hbase.HBaseResources._
 import org.apache.spark.sql.sources.Filter
@@ -96,7 +95,7 @@ private[hbase] class HBaseTableScanRDD(
             s"rowkeyLength ${r.length}  tmp: $tmp")
         }
         if (tmp > 0) {
-          Utils.getRowCol(x, r, x.start, tmp)
+          Utils.hbaseFieldToScalaType(x, r, x.start, tmp)
         } else {
           null
         }
@@ -106,12 +105,11 @@ private[hbase] class HBaseTableScanRDD(
           null
         } else {
           val v = CellUtil.cloneValue(kv)
-          Utils.getRowCol(x, v, 0, v.length)
+          Utils.hbaseFieldToScalaType(x, v, 0, v.length)
         }
       }
     }
-    val schema = StructType(requiredColumns.map(relation.schema(_)))
-    new GenericRowWithSchema(valueSeq.toArray, schema)
+    Row.fromSeq(valueSeq)
   }
 
   private def toResultIterator(result: GetResource): Iterator[Result] = {

--- a/src/main/scala/org/apache/spark/sql/execution/datasources/hbase/ScanRange.scala
+++ b/src/main/scala/org/apache/spark/sql/execution/datasources/hbase/ScanRange.scala
@@ -20,8 +20,7 @@ package org.apache.spark.sql.execution.datasources.hbase
 import org.apache.hadoop.hbase.util.Bytes
 import org.apache.spark.Logging
 import org.apache.spark.sql.execution.datasources.hbase
-import org.apache.spark.sql.execution.datasources.hbase.BoundRange
-import org.apache.spark.sql.types.UTF8String
+import org.apache.spark.unsafe.types.UTF8String
 
 import scala.collection.mutable.ArrayBuffer
 import scala.math.Ordering
@@ -380,8 +379,8 @@ object BoundRange extends Logging{
     case a: UTF8String =>
       val b = a.getBytes
       Some(BoundRanges(
-        Array(BoundRange(Array.fill(a.length)(ByteMin), b)),
-        Array(BoundRange(b, Array.fill(a.length)(ByteMax))), b))
+        Array(BoundRange(Array.fill(a.numBytes())(ByteMin), b)),
+        Array(BoundRange(b, Array.fill(a.numBytes())(ByteMax))), b))
     case _ => None
   }
 }

--- a/src/main/scala/org/apache/spark/sql/execution/datasources/hbase/Utils.scala
+++ b/src/main/scala/org/apache/spark/sql/execution/datasources/hbase/Utils.scala
@@ -24,7 +24,12 @@ import org.apache.spark.unsafe.types.UTF8String
 
 object Utils {
 
-  def getRowCol(
+  /**
+   * Parses the hbase field to it's corresponding
+   * scala type which can then be put into a Spark GenericRow
+   * which is then automatically converted by Spark.
+   */
+  def hbaseFieldToScalaType(
       f: Field,
       src: HBaseType,
       offset: Int,

--- a/src/main/scala/org/apache/spark/sql/execution/datasources/hbase/Utils.scala
+++ b/src/main/scala/org/apache/spark/sql/execution/datasources/hbase/Utils.scala
@@ -17,56 +17,44 @@
 
 package org.apache.spark.sql.execution.datasources.hbase
 
-import java.util
-import java.util.Comparator
-
-import org.apache.avro.generic.GenericRecord
 import org.apache.hadoop.hbase.util.Bytes
-import org.apache.spark.sql.catalyst.expressions.MutableRow
-import org.apache.spark.sql.catalyst.util._
 import org.apache.spark.sql.execution.SparkSqlSerializer
 import org.apache.spark.sql.types._
-
-import scala.collection.mutable.ArrayBuffer
-import scala.math.Ordering
+import org.apache.spark.unsafe.types.UTF8String
 
 object Utils {
 
-  def setRowCol(
-      row: MutableRow,
-      field: (Field, Int),
+  def getRowCol(
+      f: Field,
       src: HBaseType,
       offset: Int,
-      length: Int): Unit = {
-    val index = field._2
-    val f = field._1
+      length: Int): Any = {
     if (f.sedes.isDefined) {
       // If we already have sedes defined , use it.
-      val m = f.sedes.get.deserialize(src, offset, length)
-      row.update(index, m)
+      f.sedes.get.deserialize(src, offset, length)
     } else if (f.exeSchema.isDefined) {
       // println("avro schema is defined to do deserialization")
       // If we have avro schema defined, use it to get record, and then covert them to catalyst data type
       val m = AvroSedes.deserialize(src, f.exeSchema.get)
       // println(m)
       val n = f.avroToCatalyst.map(_(m))
-      row.update(index, n.get)
+      n.get
     } else  {
       // Fall back to atomic type
       f.dt match {
-        case BooleanType => row.setBoolean(index, toBoolean(src, offset))
-        case ByteType => row.setByte(index, src(offset))
-        case DoubleType => row.setDouble(index, Bytes.toDouble(src, offset))
-        case FloatType => row.setFloat(index, Bytes.toFloat(src, offset))
-        case IntegerType => row.setInt(index, Bytes.toInt(src, offset))
-        case LongType => row.setLong(index, Bytes.toLong(src, offset))
-        case ShortType => row.setShort(index, Bytes.toShort(src, offset))
-        case StringType => row.update(index, toUTF8String(src, offset, length))
+        case BooleanType => toBoolean(src, offset)
+        case ByteType => src(offset)
+        case DoubleType => Bytes.toDouble(src, offset)
+        case FloatType => Bytes.toFloat(src, offset)
+        case IntegerType => Bytes.toInt(src, offset)
+        case LongType => Bytes.toLong(src, offset)
+        case ShortType => Bytes.toShort(src, offset)
+        case StringType => toUTF8String(src, offset, length)
         case BinaryType =>
           val newArray = new Array[Byte](length)
           System.arraycopy(src, offset, newArray, 0, length)
-          row.update(index, newArray)
-        case _ => row.update(index, SparkSqlSerializer.deserialize[Any](src)) //TODO
+          newArray
+        case _ => SparkSqlSerializer.deserialize[Any](src) //TODO
       }
     }
   }
@@ -102,6 +90,6 @@ object Utils {
   }
 
   def toUTF8String(input: HBaseType, offset: Int, length: Int): UTF8String = {
-    UTF8String(input.slice(offset, offset + length))
+    UTF8String.fromBytes(input.slice(offset, offset + length))
   }
 }

--- a/src/test/scala/org/apache/spark/sql/SHC.scala
+++ b/src/test/scala/org/apache/spark/sql/SHC.scala
@@ -20,14 +20,12 @@ package org.apache.spark.sql
 import java.io.File
 
 import com.google.common.io.Files
-import org.apache.hadoop.hbase.{HColumnDescriptor, HTableDescriptor, TableName, HBaseTestingUtility}
-import org.apache.hadoop.hbase.client.{Scan, Put, ConnectionFactory, Table}
+import org.apache.hadoop.hbase.client.Table
 import org.apache.hadoop.hbase.util.Bytes
+import org.apache.hadoop.hbase.{HBaseTestingUtility, TableName}
 import org.apache.spark.sql.execution.datasources.hbase.SparkHBaseConf
-import org.apache.spark.sql.types.UTF8String
-import org.apache.spark.{SparkContext, SparkConf, Logging}
+import org.apache.spark.{Logging, SparkConf}
 import org.scalatest.{BeforeAndAfterAll, BeforeAndAfterEach, FunSuite}
-import scala.collection.JavaConverters._
 
 class SHC  extends FunSuite with BeforeAndAfterEach with BeforeAndAfterAll  with Logging {
   implicit class StringToColumn(val sc: StringContext) {

--- a/src/test/scala/org/apache/spark/sql/TestUtils.scala
+++ b/src/test/scala/org/apache/spark/sql/TestUtils.scala
@@ -1,18 +1,7 @@
 package org.apache.spark.sql
 
 import java.nio.ByteBuffer
-import java.io.{IOException, File}
-import java.nio.ByteBuffer
-import java.util
-
-import org.apache.avro.generic.GenericData
-
-import scala.collection.immutable.HashSet
-import scala.collection.mutable.ArrayBuffer
-import scala.util.Random
-
-import com.google.common.io.Files
-import org.apache.spark.sql.SQLContext
+import java.util.{ArrayList, HashMap}
 
 import scala.util.Random
 
@@ -26,15 +15,15 @@ object TestUtils {
   }
 
   def generateRandomMap(rand: Random, size: Int): java.util.Map[String, Int] = {
-    val jMap = new util.HashMap[String, Int]()
+    val jMap = new HashMap[String, Int]()
     for (i <- 0 until size) {
       jMap.put(rand.nextString(5), i)
     }
     jMap
   }
 
-  def generateRandomArray(rand: Random, size: Int): util.ArrayList[Boolean] = {
-    val vec = new util.ArrayList[Boolean]()
+  def generateRandomArray(rand: Random, size: Int): ArrayList[Boolean] = {
+    val vec = new ArrayList[Boolean]()
     for (i <- 0 until size) {
       vec.add(rand.nextBoolean())
     }


### PR DESCRIPTION
Upgrades to Spark 1.6 without the need for using internal row. This allows us to keep SchemaConverters.scala the same and eventually use the one in spark-avro that has now been made public.