### PR TITLE
Variable length key partial support.

### DIFF
--- a/src/main/scala/org/apache/spark/sql/execution/datasources/hbase/HBaseRelation.scala
+++ b/src/main/scala/org/apache/spark/sql/execution/datasources/hbase/HBaseRelation.scala
@@ -17,30 +17,21 @@
 
 package org.apache.spark.sql.execution.datasources.hbase
 
-import java.io.{IOException, ObjectInputStream, ObjectOutputStream, ByteArrayInputStream}
+import java.io.{IOException, ObjectInputStream, ObjectOutputStream}
 
-import org.apache.avro.Schema
-import org.apache.avro.generic.{GenericDatumWriter, GenericDatumReader, GenericRecord}
-import org.apache.avro.io._
-import org.apache.commons.io.output.ByteArrayOutputStream
 import org.apache.hadoop.conf.Configuration
+import org.apache.hadoop.hbase.client.{ConnectionFactory, Put}
 import org.apache.hadoop.hbase.io.ImmutableBytesWritable
 import org.apache.hadoop.hbase.mapred.TableOutputFormat
-import org.apache.hadoop.hbase.mapreduce.TableInputFormat
-import org.apache.hadoop.hbase.{HColumnDescriptor, HTableDescriptor, TableName, HBaseConfiguration}
-import org.apache.hadoop.hbase.client.{HBaseAdmin, Put, ConnectionFactory, Table}
 import org.apache.hadoop.hbase.util.Bytes
+import org.apache.hadoop.hbase.{HBaseConfiguration, HColumnDescriptor, HTableDescriptor, TableName}
 import org.apache.hadoop.mapred.JobConf
 import org.apache.spark.Logging
 import org.apache.spark.rdd.RDD
-import org.apache.spark.sql.types._
-import org.apache.spark.sql.{SaveMode, DataFrame, Row, SQLContext}
 import org.apache.spark.sql.sources._
-import org.json4s.JsonAST.JValue
-import org.json4s.jackson.JsonMethods._
+import org.apache.spark.sql.types._
+import org.apache.spark.sql.{DataFrame, Row, SQLContext, SaveMode}
 
-import scala.collection.JavaConverters._
-import scala.collection.mutable
 import scala.util.control.NonFatal
 
 /**

--- a/src/main/scala/org/apache/spark/sql/execution/datasources/hbase/HBaseTableCatalog.scala
+++ b/src/main/scala/org/apache/spark/sql/execution/datasources/hbase/HBaseTableCatalog.scala
@@ -66,7 +66,7 @@ case class Field(
     }
   }
 
-  var length: Int = {
+  val length: Int = {
     if (len == -1) {
       dt match {
         case BinaryType | StringType => -1
@@ -133,37 +133,6 @@ case class HBaseTableCatalog(
   def getPrimaryKey= row.keys(0)
   def getColumnFamilies = {
     sMap.fields.map(_.cf).filter(_ != HBaseTableCatalog.rowKey)
-  }
-
-  // Setup the start and length for each dimension of row key at runtime.
-  def dynSetupRowKey(rowKey: HBaseType) {
-    logDebug(s"length: ${rowKey.length}")
-    if(row.varLength) {
-      var start = 0
-      row.fields.foreach { f =>
-        logDebug(s"start: $start")
-        f.start = start
-        f.length = {
-          // If the length is not defined
-          if (f.length == -1) {
-            f.dt match {
-              case StringType =>
-                var pos = rowKey.indexOf(HBaseTableCatalog.delimiter, start)
-                if (pos == -1 || pos > rowKey.length) {
-                  // this is at the last dimension
-                  pos = rowKey.length
-                }
-                pos - start
-              // We don't know the length, assume it extend to the end of the rowkey.
-              case _ => rowKey.length - start
-            }
-          } else {
-            f.length
-          }
-        }
-        start += f.length
-      }
-    }
   }
 
   def initRowKey = {


### PR DESCRIPTION
This is partial support because it doesn't handle the situation where you have variable keys inbetween fixed length keys.

For example: `string(6):string(?):int` would not work because we don't actually write delimiters with the variable length string.

To support this, we need to add the `HBaseTableCatalog.delimiter` after the end of variable length strings. Parsing this into a row object is already supported with the current code, but the filter logic in HBaseFilter.scala breaks because we need to disable push down filters on keys which are after the fixed length portion (ie. the int column in the above example).

Altogether the logic in HBaseFilter is kind of sketchy because it treats LessThan and LessThanEqualTo (as well as the GreaterThan counterpart) as the same, so we should probably rethink that.