### PR TITLE
Performance improvements and bug fixes with In/Not In filters

### DIFF
--- a/src/main/scala/org/apache/spark/sql/execution/datasources/hbase/HBaseFilter.scala
+++ b/src/main/scala/org/apache/spark/sql/execution/datasources/hbase/HBaseFilter.scala
@@ -387,9 +387,9 @@ object HBaseFilter extends Logging{
       case Not(In(attribute: String, values: Array[Any])) =>
         //converting a "not(key in (x1, x2, x3..)) filter to (key != x1) and (key != x2) and ..
         values.map{v => buildFilter(Not(EqualTo(attribute, v)),relation)}
-              .foldLeft(HRF.empty[Array[Byte]]){
+              .reduceOption[HRF[Array[Byte]]]{
                   case (lhs, rhs) => and(lhs,rhs)
-              }
+              }.getOrElse(HRF.empty[Array[Byte]])
       case _ => HRF.empty[Array[Byte]]
     }
     logDebug(s"""start filter $filter:  ${f.ranges.map(_.toString).mkString(" ")}""")

--- a/src/main/scala/org/apache/spark/sql/execution/datasources/hbase/HBaseFilter.scala
+++ b/src/main/scala/org/apache/spark/sql/execution/datasources/hbase/HBaseFilter.scala
@@ -25,7 +25,6 @@ import org.apache.hadoop.hbase.util.Bytes
 import org.apache.spark.Logging
 import org.apache.spark.sql.execution.datasources.hbase
 import org.apache.spark.sql.execution.datasources.hbase.FilterType.FilterType
-import org.apache.spark.sql.execution.datasources.hbase.TypedFilter
 import org.apache.spark.sql.sources._
 import org.apache.spark.sql.types.BinaryType
 import scala.collection.JavaConverters._
@@ -376,15 +375,16 @@ object HBaseFilter extends Logging{
         HRF(Array(ScanRange.empty[Array[Byte]]), TypedFilter(Some(filter), FilterType.Atomic))
       case In(attribute: String, values: Array[Any]) =>
         //converting a "key in (x1, x2, x3..) filter to (key == x1) or (key == x2) or ...
-        //this may be a temporary hack to get this filter working
-        val filter = values.map(v => EqualTo(attribute, v)).reduce[Filter]{case (op1, op2) => Or(op1, op2)}
-        buildFilter(filter, relation)
-
+          values.map{v => buildFilter(EqualTo(attribute, v), relation)}
+                .foldLeft(HRF.empty[Array[Byte]]){
+                  case (lhs, rhs) => or(lhs,rhs)
+                }
       case Not(In(attribute: String, values: Array[Any])) =>
-        //converting a "key in (x1, x2, x3..) filter to (key == x1) or (key == x2) or ...
-        //this may be a temporary hack to get this filter working
-        val filter = values.map(v => Not(EqualTo(attribute, v))).reduce[Filter]{case (op1, op2) => And(op1, op2)}
-        buildFilter(filter, relation)
+        //converting a "not(key in (x1, x2, x3..)) filter to (key != x1) and (key != x2) and ..
+        values.map{v => buildFilter(Not(EqualTo(attribute, v)),relation)}
+              .foldLeft(HRF.empty[Array[Byte]]){
+                  case (lhs, rhs) => and(lhs,rhs)
+              }
       case _ => HRF.empty[Array[Byte]]
     }
     logDebug(s"""start filter $filter:  ${f.ranges.map(_.toString).mkString(" ")}""")

--- a/src/main/scala/org/apache/spark/sql/execution/datasources/hbase/HBaseFilter.scala
+++ b/src/main/scala/org/apache/spark/sql/execution/datasources/hbase/HBaseFilter.scala
@@ -375,10 +375,15 @@ object HBaseFilter extends Logging{
         HRF(Array(ScanRange.empty[Array[Byte]]), TypedFilter(Some(filter), FilterType.Atomic))
       case In(attribute: String, values: Array[Any]) =>
         //converting a "key in (x1, x2, x3..) filter to (key == x1) or (key == x2) or ...
-          values.map{v => buildFilter(EqualTo(attribute, v), relation)}
-                .foldLeft(HRF.empty[Array[Byte]]){
-                  case (lhs, rhs) => or(lhs,rhs)
-                }
+        val ranges = new ArrayBuffer[ScanRange[Array[Byte]]]()
+        values.foreach{
+          value =>
+            val sparkFilter = EqualTo(attribute,value)
+            val hbaseFilter = buildFilter(sparkFilter,relation)
+            ranges ++= hbaseFilter.ranges
+        }
+        val result = HRF[Array[Byte]](ranges.toArray, TypedFilter.empty)
+        result
       case Not(In(attribute: String, values: Array[Any])) =>
         //converting a "not(key in (x1, x2, x3..)) filter to (key != x1) and (key != x2) and ..
         values.map{v => buildFilter(Not(EqualTo(attribute, v)),relation)}

--- a/src/main/scala/org/apache/spark/sql/execution/datasources/hbase/HBaseTableScan.scala
+++ b/src/main/scala/org/apache/spark/sql/execution/datasources/hbase/HBaseTableScan.scala
@@ -176,6 +176,7 @@ private[hbase] class HBaseTableScanRDD(
       it: Iterator[Result]): Iterator[Row] = {
 
     val iterator = new Iterator[Row] {
+      val start         = System.currentTimeMillis()
       var rowCount: Int = 0
       val indexedFields = relation.getIndexedProjections(requiredColumns).map(_._1)
 
@@ -184,7 +185,8 @@ private[hbase] class HBaseTableScanRDD(
           true
         }
         else {
-          logDebug(s"returned ${rowCount} rows from hbase")
+          val end = System.currentTimeMillis()
+          logDebug(s"returned ${rowCount} rows from hbase in ${end - start} ms")
           false
         }
       }

--- a/src/test/scala/org/apache/spark/sql/DefaultSourceSuite.scala
+++ b/src/test/scala/org/apache/spark/sql/DefaultSourceSuite.scala
@@ -109,6 +109,28 @@ class DefaultSourceSuite extends SHC with Logging {
     assert(s.count() == 1)
   }
 
+  test("IN filter stack overflow") {
+    val df = withCatalog(catalog)
+    val items          = (0 to 2000).map{i => s"xaz${i}"}
+    val filterInItems  = Seq("row001") ++: items
+
+    val s = df.filter($"col0" isin(filterInItems:_*)).select("col0")
+    s.explain(true)
+    s.show()
+    assert(s.count() == 1)
+  }
+
+  test("NOT IN filter stack overflow") {
+    val df               = withCatalog(catalog)
+    val items            = (0 to 2000).map{i => s"xaz${i}"}
+    var filterNotInItems = items
+
+    val s = df.filter(not($"col0" isin(filterNotInItems:_*))).select("col0")
+    s.explain(true)
+    s.show
+    assert(s.count() == df.count())
+  }
+
   test("full query") {
     val df = withCatalog(catalog)
     df.show

--- a/src/test/scala/org/apache/spark/sql/DefaultSourceSuite.scala
+++ b/src/test/scala/org/apache/spark/sql/DefaultSourceSuite.scala
@@ -147,6 +147,21 @@ class DefaultSourceSuite extends SHC with Logging {
     assert(rows.size == 1)
   }
 
+  ignore("NOT IN filter, RDD") {
+    val items   = Array[Any]("row001")
+    val scan    = prunedFilterScan(catalog)
+    val columns = Array("col0")
+    val filters =
+      Array[org.apache.spark.sql.sources.Filter](
+        org.apache.spark.sql.sources.Not(
+          org.apache.spark.sql.sources.In("col0", items))
+      )
+
+    val rows    = scan.buildScan(columns,filters).collect()
+    val df      = withCatalog(catalog).filter(not($"col0".isin(items:_*)))
+    assert(rows.size == df.count())
+  }
+
   test("full query") {
     val df = withCatalog(catalog)
     df.show


### PR DESCRIPTION
When there are a large number of items for In/Not In clause, I am getting stack overflow errors as part of HBaseFilter.buildFilter. I've created a pull request that has the test cases + fixes.